### PR TITLE
Fix image container size in SkillsFooter

### DIFF
--- a/src/components/SkillsFooter.tsx
+++ b/src/components/SkillsFooter.tsx
@@ -12,7 +12,7 @@ const SkillsFooter: React.FC<MyComponentProps> = ({ items }) => {
                 items.map((val, indx) => {
                     return (
                         <div className="p-4" key={indx}>
-                            <div className="relative size-20 hover:scale-125 transition duration-200 ease-in-out">
+                            <div className="relative w-20 h-20 hover:scale-125 transition duration-200 ease-in-out">
                                 <Image
                                     src={val?.img}
                                     alt={val?.alt}


### PR DESCRIPTION
## Summary
- set explicit width and height for `SkillsFooter` images

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688c36d78f148323be8251f0274e678b